### PR TITLE
QQDB-2959(fix) - Added string to query result types

### DIFF
--- a/src/QdbQueryPoint.c
+++ b/src/QdbQueryPoint.c
@@ -42,7 +42,8 @@ void QdbQueryPoint_createInstance(zval* destination, qdb_point_result_t* point)
         ZVAL_STRINGL(&this->value, point->payload.blob.content, point->payload.blob.content_length);
         return;
     case qdb_query_result_string:
-        if (QDB_IS_NULL_STRING(point->payload.string)) break;
+        // TODO(Sidney): Use QDB_IS_NULL_STRING when it doesn't use nullptr anymore in the C API.
+        if (QDB_IS_NULL_BLOB(point->payload.string)) break;
         ZVAL_STRINGL(&this->value, point->payload.string.content, point->payload.string.content_length);
         return;
     case qdb_query_result_double:

--- a/src/QdbQueryPoint.c
+++ b/src/QdbQueryPoint.c
@@ -21,6 +21,7 @@ extern zend_class_entry* ce_QdbQueryPoint;
 int init_query_point_types() {
     return zend_declare_class_constant_long(ce_QdbQueryPoint, "NONE", sizeof("NONE")-1, qdb_query_result_none) == SUCCESS
         && zend_declare_class_constant_long(ce_QdbQueryPoint, "BLOB", sizeof("BLOB")-1, qdb_query_result_blob) == SUCCESS
+        && zend_declare_class_constant_long(ce_QdbQueryPoint, "STRING", sizeof("STRING")-1, qdb_query_result_string) == SUCCESS
         && zend_declare_class_constant_long(ce_QdbQueryPoint, "COUNT", sizeof("COUNT")-1, qdb_query_result_count) == SUCCESS
         && zend_declare_class_constant_long(ce_QdbQueryPoint, "DOUBLE", sizeof("DOUBLE")-1, qdb_query_result_double) == SUCCESS
         && zend_declare_class_constant_long(ce_QdbQueryPoint, "INT64", sizeof("INT64")-1, qdb_query_result_int64) == SUCCESS
@@ -39,6 +40,10 @@ void QdbQueryPoint_createInstance(zval* destination, qdb_point_result_t* point)
     case qdb_query_result_blob:
         if (QDB_IS_NULL_BLOB(point->payload.blob)) break;
         ZVAL_STRINGL(&this->value, point->payload.blob.content, point->payload.blob.content_length);
+        return;
+    case qdb_query_result_string:
+        if (QDB_IS_NULL_STRING(point->payload.string)) break;
+        ZVAL_STRINGL(&this->value, point->payload.string.content, point->payload.string.content_length);
         return;
     case qdb_query_result_double:
         if (QDB_IS_NULL_DOUBLE(point->payload.double_)) break;

--- a/test/QdbQuery/QdbQueryEffectsTest.php
+++ b/test/QdbQuery/QdbQueryEffectsTest.php
@@ -54,17 +54,13 @@ class QdbQueryEffectsTest extends QdbTestBase
     public function testNullValues()
     {
         try {
-            print("T1");
-            $this->checkEmptyQuery('CREATE TABLE flavours(str STRING, int64 INT64, ts TIMESTAMP, f64 DOUBLE)');
-            print("T2");
+            $this->checkEmptyQuery('CREATE TABLE flavours(str BLOB, int64 INT64, ts TIMESTAMP, f64 DOUBLE)');
             $this->checkEmptyQuery('INSERT INTO  flavours($timestamp, str, int64, ts, f64) VALUES'.
                                    '  (now, "Alice", null, null, null)'.
                                    ', (now, "Bob",   22,   1970, null)'.
                                    ', (now, null,    23,   null, null)');
-            print("T3");
 
             $query = $this->cluster->makeQuery('SELECT count(int64), str, int64, ts, f64 FROM flavours');
-            print("T4");
 
             $this->assertEquals($query->columnNames(), ['count(int64)', 'str', 'int64', 'ts', 'f64']);
             $this->assertEquals(count($query->rows()), 4);
@@ -81,7 +77,7 @@ class QdbQueryEffectsTest extends QdbTestBase
             $this->assertEquals($query->rows()[0][4]->value(), null);
 
             $this->assertEquals($query->rows()[1][0]->type(), QdbQueryPoint::NONE);
-            $this->assertEquals($query->rows()[1][1]->type(), QdbQueryPoint::STRING);
+            $this->assertEquals($query->rows()[1][1]->type(), QdbQueryPoint::BLOB);
             $this->assertEquals($query->rows()[1][2]->type(), QdbQueryPoint::NONE);
             $this->assertEquals($query->rows()[1][3]->type(), QdbQueryPoint::NONE);
             $this->assertEquals($query->rows()[1][4]->type(), QdbQueryPoint::NONE);
@@ -92,7 +88,7 @@ class QdbQueryEffectsTest extends QdbTestBase
             $this->assertEquals($query->rows()[1][4]->value(), null);
 
             $this->assertEquals($query->rows()[2][0]->type(), QdbQueryPoint::NONE);
-            $this->assertEquals($query->rows()[2][1]->type(), QdbQueryPoint::STRING);
+            $this->assertEquals($query->rows()[2][1]->type(), QdbQueryPoint::BLOB);
             $this->assertEquals($query->rows()[2][2]->type(), QdbQueryPoint::INT64);
             $this->assertEquals($query->rows()[2][3]->type(), QdbQueryPoint::TIMESTAMP);
             $this->assertEquals($query->rows()[2][4]->type(), QdbQueryPoint::NONE);

--- a/test/QdbQuery/QdbQueryEffectsTest.php
+++ b/test/QdbQuery/QdbQueryEffectsTest.php
@@ -29,7 +29,7 @@ class QdbQueryEffectsTest extends QdbTestBase
             $this->assertEquals($query->columnNames(), ['$timestamp', '$table', 'name', 'age']);
 
             $this->assertEquals($query->rows()[0][0]->type(), QdbQueryPoint::TIMESTAMP);
-            $this->assertEquals($query->rows()[0][1]->type(), QdbQueryPoint::BLOB);
+            $this->assertEquals($query->rows()[0][1]->type(), QdbQueryPoint::STRING);
             $this->assertEquals($query->rows()[0][2]->type(), QdbQueryPoint::BLOB);
             $this->assertEquals($query->rows()[0][3]->type(), QdbQueryPoint::INT64);
             $this->assertEquals($query->rows()[0][0]->value(), new QdbTimestamp(0, 0));
@@ -38,7 +38,7 @@ class QdbQueryEffectsTest extends QdbTestBase
             $this->assertEquals($query->rows()[0][3]->value(), 21);
 
             $this->assertEquals($query->rows()[1][0]->type(), QdbQueryPoint::TIMESTAMP);
-            $this->assertEquals($query->rows()[1][1]->type(), QdbQueryPoint::BLOB);
+            $this->assertEquals($query->rows()[1][1]->type(), QdbQueryPoint::STRING);
             $this->assertEquals($query->rows()[1][2]->type(), QdbQueryPoint::BLOB);
             $this->assertEquals($query->rows()[1][3]->type(), QdbQueryPoint::INT64);
             $this->assertEquals($query->rows()[1][0]->value(), new QdbTimestamp(1, 0));
@@ -54,13 +54,17 @@ class QdbQueryEffectsTest extends QdbTestBase
     public function testNullValues()
     {
         try {
+            print("T1");
             $this->checkEmptyQuery('CREATE TABLE flavours(str STRING, int64 INT64, ts TIMESTAMP, f64 DOUBLE)');
+            print("T2");
             $this->checkEmptyQuery('INSERT INTO  flavours($timestamp, str, int64, ts, f64) VALUES'.
                                    '  (now, "Alice", null, null, null)'.
                                    ', (now, "Bob",   22,   1970, null)'.
                                    ', (now, null,    23,   null, null)');
+            print("T3");
 
             $query = $this->cluster->makeQuery('SELECT count(int64), str, int64, ts, f64 FROM flavours');
+            print("T4");
 
             $this->assertEquals($query->columnNames(), ['count(int64)', 'str', 'int64', 'ts', 'f64']);
             $this->assertEquals(count($query->rows()), 4);

--- a/test/QdbQuery/QdbQueryEffectsTest.php
+++ b/test/QdbQuery/QdbQueryEffectsTest.php
@@ -54,15 +54,15 @@ class QdbQueryEffectsTest extends QdbTestBase
     public function testNullValues()
     {
         try {
-            $this->checkEmptyQuery('CREATE TABLE flavours(blob BLOB, int64 INT64, ts TIMESTAMP, f64 DOUBLE)');
-            $this->checkEmptyQuery('INSERT INTO  flavours($timestamp, blob, int64, ts, f64) VALUES'.
+            $this->checkEmptyQuery('CREATE TABLE flavours(str STRING, int64 INT64, ts TIMESTAMP, f64 DOUBLE)');
+            $this->checkEmptyQuery('INSERT INTO  flavours($timestamp, str, int64, ts, f64) VALUES'.
                                    '  (now, "Alice", null, null, null)'.
                                    ', (now, "Bob",   22,   1970, null)'.
                                    ', (now, null,    23,   null, null)');
 
-            $query = $this->cluster->makeQuery('SELECT count(int64), blob, int64, ts, f64 FROM flavours');
+            $query = $this->cluster->makeQuery('SELECT count(int64), str, int64, ts, f64 FROM flavours');
 
-            $this->assertEquals($query->columnNames(), ['count(int64)', 'blob', 'int64', 'ts', 'f64']);
+            $this->assertEquals($query->columnNames(), ['count(int64)', 'str', 'int64', 'ts', 'f64']);
             $this->assertEquals(count($query->rows()), 4);
 
             $this->assertEquals($query->rows()[0][0]->type(), QdbQueryPoint::COUNT);
@@ -77,7 +77,7 @@ class QdbQueryEffectsTest extends QdbTestBase
             $this->assertEquals($query->rows()[0][4]->value(), null);
 
             $this->assertEquals($query->rows()[1][0]->type(), QdbQueryPoint::NONE);
-            $this->assertEquals($query->rows()[1][1]->type(), QdbQueryPoint::BLOB);
+            $this->assertEquals($query->rows()[1][1]->type(), QdbQueryPoint::STRING);
             $this->assertEquals($query->rows()[1][2]->type(), QdbQueryPoint::NONE);
             $this->assertEquals($query->rows()[1][3]->type(), QdbQueryPoint::NONE);
             $this->assertEquals($query->rows()[1][4]->type(), QdbQueryPoint::NONE);
@@ -88,7 +88,7 @@ class QdbQueryEffectsTest extends QdbTestBase
             $this->assertEquals($query->rows()[1][4]->value(), null);
 
             $this->assertEquals($query->rows()[2][0]->type(), QdbQueryPoint::NONE);
-            $this->assertEquals($query->rows()[2][1]->type(), QdbQueryPoint::BLOB);
+            $this->assertEquals($query->rows()[2][1]->type(), QdbQueryPoint::STRING);
             $this->assertEquals($query->rows()[2][2]->type(), QdbQueryPoint::INT64);
             $this->assertEquals($query->rows()[2][3]->type(), QdbQueryPoint::TIMESTAMP);
             $this->assertEquals($query->rows()[2][4]->type(), QdbQueryPoint::NONE);

--- a/test/QdbTsBatchTable/QdbTsBatchTablePushValuesTest.php
+++ b/test/QdbTsBatchTable/QdbTsBatchTablePushValuesTest.php
@@ -33,8 +33,8 @@ class QdbTsBatchTablePushValuesTest extends QdbTestBase
             $this->assertEquals($query->columnNames(), ['$timestamp', '$table', 'name', 'age']);
             $this->assertEquals($query->rows()[0][0]->type(), QdbQueryPoint::TIMESTAMP);
             $this->assertEquals($query->rows()[1][0]->type(), QdbQueryPoint::TIMESTAMP);
-            $this->assertEquals($query->rows()[0][1]->type(), QdbQueryPoint::BLOB);
-            $this->assertEquals($query->rows()[1][1]->type(), QdbQueryPoint::BLOB);
+            $this->assertEquals($query->rows()[0][1]->type(), QdbQueryPoint::STRING);
+            $this->assertEquals($query->rows()[1][1]->type(), QdbQueryPoint::STRING);
             $this->assertEquals($query->rows()[0][2]->type(), QdbQueryPoint::BLOB);
             $this->assertEquals($query->rows()[1][2]->type(), QdbQueryPoint::BLOB);
             $this->assertEquals($query->rows()[0][3]->type(), QdbQueryPoint::INT64);


### PR DESCRIPTION
Now expects strings for $table column.